### PR TITLE
Call correct overload of log.FatalAsync

### DIFF
--- a/MetroLog.Shared.WinRT/GlobalCrashHandler.cs
+++ b/MetroLog.Shared.WinRT/GlobalCrashHandler.cs
@@ -26,7 +26,7 @@ namespace MetroLog
 
             // go...
             var log = (ILoggerAsync)pcl::MetroLog.LogManagerFactory.DefaultLogManager.GetLogger<Application>();
-            await log.FatalAsync("The application crashed: " + e.Message, e.Exception);
+            await log.FatalAsync("The application crashed: " + e.Message, e);
 
             // if we're aborting, fake a suspend to flush the targets...
             await LazyFlushManager.FlushAllAsync(new LogWriteContext());


### PR DESCRIPTION
The method was previously hitting `FatalSync(string message, params object[] args)` and thereby throwing away the exception object as it wasn't referenced in the message. The change ensures that `FatalSync(string message, Exception ex)` is hit and the exception information is logged correctly.